### PR TITLE
feat: get rid of `Identification`

### DIFF
--- a/scripts/transformer/src/main/java/org/unece/uncefact/vocab/transformers/BSPToJSONLDVocabulary.java
+++ b/scripts/transformer/src/main/java/org/unece/uncefact/vocab/transformers/BSPToJSONLDVocabulary.java
@@ -61,7 +61,11 @@ public class BSPToJSONLDVocabulary extends Transformer {
             entity.setObjectClassTermQualifier(getStringCellValue(row, 7, false));
             entity.setObjectClassTerm(getStringCellValue(row, 8));
             entity.setPropertyTermQualifier(getStringCellValue(row, 9));
-            entity.setPropertyTerm(getStringCellValue(row, 10));
+            if (!getStringCellValue(row, 10).equals("Identification")) {
+                entity.setPropertyTerm(getStringCellValue(row, 10));
+            } else {
+                entity.setPropertyTerm("");
+            }
             entity.setDataTypeQualifier(getStringCellValue(row, 11));
             entity.setRepresentationTerm(getStringCellValue(row, 12));
             entity.setQualifiedDataTypeId(getStringCellValue(row, 13));


### PR DESCRIPTION
@kshychko, expecting you to keep me on the straight and narrow here! 

An example of a consequence of this `"@id": "unece:bICId",` which now gets clubbed together as this: 
```
      "schema:domainIncludes": [
        {
          "@id": "unece:FinancialInstitution"
        },
        {
          "@id": "unece:Identity"
        }
      ],
```
A sort of double-inheritance. Unless this is breaking some rule I am not aware of, this seems to make sense. 