### PR TITLE
feat: getting rid of "formatted" datetime

### DIFF
--- a/scripts/transformer/src/main/java/org/unece/uncefact/vocab/transformers/BSPToJSONLDVocabulary.java
+++ b/scripts/transformer/src/main/java/org/unece/uncefact/vocab/transformers/BSPToJSONLDVocabulary.java
@@ -62,7 +62,11 @@ public class BSPToJSONLDVocabulary extends Transformer {
             entity.setObjectClassTerm(getStringCellValue(row, 8));
             entity.setPropertyTermQualifier(getStringCellValue(row, 9));
             entity.setPropertyTerm(getStringCellValue(row, 10));
-            entity.setDataTypeQualifier(getStringCellValue(row, 11));
+            if(!getStringCellValue(row, 11).equals("Formatted")) {
+                entity.setDataTypeQualifier(getStringCellValue(row, 11));
+            } else {
+                entity.setDataTypeQualifier("");
+            }
             entity.setRepresentationTerm(getStringCellValue(row, 12));
             entity.setQualifiedDataTypeId(getStringCellValue(row, 13));
             entity.setAssociatedObjectClassTermQualifier(getStringCellValue(row, 14));


### PR DESCRIPTION
@kshychko, again: keep me brutally honest! It's hard to feel certain that I grasp the full consequences of my actions. 

But from what I can tell this is a huge improvement. Example: instead of `"@id": "unece:formattedExpiryDateTime"` it now produces `"@id": "unece:certifiedAccreditationExpiryDateTime" `. That's incredibly more descriptive and useful. 