### PR TITLE
fix: doublons in property names

### DIFF
--- a/scripts/transformer/pom.xml
+++ b/scripts/transformer/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.unece.uncefact</groupId>
     <artifactId>vocab-transformer</artifactId>
-    <version>1.0.0-rc5</version>
+    <version>1.0.0-rc6</version>
     <build>
         <plugins>
             <plugin>

--- a/scripts/transformer/src/main/java/org/unece/uncefact/vocab/Entity.java
+++ b/scripts/transformer/src/main/java/org/unece/uncefact/vocab/Entity.java
@@ -245,6 +245,15 @@ public class Entity {
                 }
             }
         }
+        //remove duplicated words
+        //TODO: replace with regex implementation
+        String[] split = StringUtils.splitByCharacterTypeCamelCase(propertyKey);
+        propertyKey = split[split.length-1];
+        for (int i = split.length -2; i >=0; i--){
+            if(!StringUtils.startsWithIgnoreCase(propertyKey, split[i]))
+                propertyKey = StringUtils.join(split[i], propertyKey);
+        }
+
         return propertyKey;
     }
 


### PR DESCRIPTION
Closes #51
Below are the results of property renaming when the implemented NDR rules are applied:
old name|new name|comment
-|-|-
automaticDataCaptureMethodAutomaticDataCaptureMethodTypeCode|automaticDataCaptureMethodTypeCode|
documentLineDocumentLineStatusCode|documentLineStatusCode|
dueDateDateTime|dueDateTime|(already exists in the old set)
locationFunctionFunctionTypeCode|locationFunctionTypeCode|(already exists in the old set)
logisticsSealSealingPartyRoleCode|logisticsSealingPartyRoleCode|
referenceReferenceTypeCode|referenceTypeCode|
transportServiceConditionConditionTypeCode|transportServiceConditionTypeCode|